### PR TITLE
Improve simple-runtime resilience by replacing unwrap panics

### DIFF
--- a/crates/runtimes/simple-runtime/src/api.rs
+++ b/crates/runtimes/simple-runtime/src/api.rs
@@ -19,36 +19,52 @@ async fn hello() -> impl Responder {
 #[get("/defaults/detector")]
 async fn defaults_detector() -> impl Responder {
     let settings = settings::DetectorSettings::default();
-    let str = serde_json::to_string(&settings).unwrap();
-    HttpResponse::Ok().body(str)
+    match serde_json::to_string(&settings) {
+        Ok(body) => HttpResponse::Ok().body(body),
+        Err(err) => HttpResponse::InternalServerError()
+            .body(format!("Failed to serialize detector settings: {err}")),
+    }
 }
 
 #[get("/defaults/ocr")]
 async fn defaults_ocr() -> impl Responder {
     let settings = settings::OCRSettings::default();
-    let str = serde_json::to_string(&settings).unwrap();
-    HttpResponse::Ok().body(str)
+    match serde_json::to_string(&settings) {
+        Ok(body) => HttpResponse::Ok().body(body),
+        Err(err) => HttpResponse::InternalServerError()
+            .body(format!("Failed to serialize OCR settings: {err}")),
+    }
 }
 
 #[get("/defaults/inpainter")]
 async fn defaults_inpainter() -> impl Responder {
     let settings = settings::InpainterSettings::default();
-    let str = serde_json::to_string(&settings).unwrap();
-    HttpResponse::Ok().body(str)
+    match serde_json::to_string(&settings) {
+        Ok(body) => HttpResponse::Ok().body(body),
+        Err(err) => HttpResponse::InternalServerError()
+            .body(format!("Failed to serialize inpainter settings: {err}")),
+    }
 }
 
 #[get("/defaults/mask_refinement")]
 async fn defaults_mask_refinement() -> impl Responder {
     let settings = settings::MaskRefinementSettings::default();
-    let str = serde_json::to_string(&settings).unwrap();
-    HttpResponse::Ok().body(str)
+    match serde_json::to_string(&settings) {
+        Ok(body) => HttpResponse::Ok().body(body),
+        Err(err) => HttpResponse::InternalServerError().body(format!(
+            "Failed to serialize mask refinement settings: {err}"
+        )),
+    }
 }
 
 #[get("/defaults/translator")]
 async fn defaults_translator() -> impl Responder {
     let settings = settings::TranslatorSettings::default();
-    let str = serde_json::to_string(&settings).unwrap();
-    HttpResponse::Ok().body(str)
+    match serde_json::to_string(&settings) {
+        Ok(body) => HttpResponse::Ok().body(body),
+        Err(err) => HttpResponse::InternalServerError()
+            .body(format!("Failed to serialize translator settings: {err}")),
+    }
 }
 
 const UPLOAD_DIR: &str = "./uploads";

--- a/crates/runtimes/simple-runtime/src/main.rs
+++ b/crates/runtimes/simple-runtime/src/main.rs
@@ -2,6 +2,7 @@ use std::{
     fs::{create_dir_all, File},
     io::Write,
     path::PathBuf,
+    process::ExitCode,
 };
 
 use clap::Parser as _;
@@ -29,7 +30,7 @@ mod ui;
 mod update;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> ExitCode {
     let cli = cli::Cli::parse();
     let (level, ort_level) = match cli.verbose {
         3 | 2 => ("debug", "ort=debug"),
@@ -38,7 +39,13 @@ async fn main() {
     };
 
     let base_filter = EnvFilter::new(level);
-    let filter = base_filter.add_directive(ort_level.parse().unwrap());
+    let filter = match ort_level.parse() {
+        Ok(directive) => base_filter.add_directive(directive),
+        Err(err) => {
+            eprintln!("Failed to parse ORT log directive '{ort_level}': {err}");
+            return ExitCode::FAILURE;
+        }
+    };
 
     tracing_subscriber::fmt()
         .with_level(true)
@@ -86,11 +93,18 @@ async fn main() {
             let mut settings = Config::builder();
             if let Some(config) = config {
                 if !config.exists() {
-                    panic!("Config file does not exist")
+                    error!("Config file does not exist: {}", config.display());
+                    return ExitCode::FAILURE;
                 }
                 settings = settings.add_source(config::File::from(config));
             }
-            let settings = settings.build().expect("Failed to build settings");
+            let settings = match settings.build() {
+                Ok(settings) => settings,
+                Err(err) => {
+                    error!("Failed to build settings: {err}");
+                    return ExitCode::FAILURE;
+                }
+            };
             let settings = settings.try_deserialize::<Settings>().unwrap_or_default();
             let out_ext = settings.render.renderer.extension();
             if !overwrite {
@@ -122,12 +136,21 @@ async fn main() {
                 let debug_path = if cli.verbose > 2 {
                     let id = uuid::Uuid::new_v4();
                     let p = PathBuf::from(format!("debug/{}", id.to_string()));
-                    create_dir_all(&p).expect("Failed to create debug directory");
+                    if let Err(err) = create_dir_all(&p) {
+                        error!("Failed to create debug directory {}: {}", p.display(), err);
+                        continue;
+                    }
                     Some(p)
                 } else {
                     None
                 };
-                let exp = models.execute(img, &settings, debug_path).await.unwrap();
+                let exp = match models.execute(img, &settings, debug_path).await {
+                    Ok(exp) => exp,
+                    Err(err) => {
+                        error!("Failed to process image {}: {}", path.display(), err);
+                        continue;
+                    }
+                };
                 let exp = match exp {
                     Some(v) => v,
                     None => {
@@ -139,20 +162,58 @@ async fn main() {
                 if settings.render.renderer == Renderer::Html {
                     let (data, _) = HtmlRenderer::render(vec![exp], None, false);
                     if let Some(parent) = output.parent() {
-                        create_dir_all(parent).expect("Failed to create parent directory");
-                        html::copy_files(parent).expect("Failed to copy important js files");
+                        if let Err(err) = create_dir_all(parent) {
+                            error!(
+                                "Failed to create parent directory {}: {}",
+                                parent.display(),
+                                err
+                            );
+                            continue;
+                        }
+                        if let Err(err) = html::copy_files(parent) {
+                            error!(
+                                "Failed to copy html assets to {}: {}",
+                                parent.display(),
+                                err
+                            );
+                            continue;
+                        }
                     }
-                    File::create(output).unwrap().write_all(&data).unwrap();
+                    match File::create(&output).and_then(|mut file| file.write_all(&data)) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            error!("Failed to write output file {}: {}", output.display(), err);
+                            continue;
+                        }
+                    }
                 } else {
                     let bin = exp.export();
                     if let Some(parent) = output.parent() {
-                        create_dir_all(parent).expect("Failed to create parent directory");
+                        if let Err(err) = create_dir_all(parent) {
+                            error!(
+                                "Failed to create parent directory {}: {}",
+                                parent.display(),
+                                err
+                            );
+                            continue;
+                        }
                     }
-                    File::create(output).unwrap().write_all(&bin).unwrap();
+                    match File::create(&output).and_then(|mut file| file.write_all(&bin)) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            error!("Failed to write output file {}: {}", output.display(), err);
+                            continue;
+                        }
+                    }
                 }
             }
         }
-        cli::Commands::Api { host, port } => api::main(&host, port).await.unwrap(),
+        cli::Commands::Api { host, port } => {
+            if let Err(err) = api::main(&host, port).await {
+                error!("API server failed: {}", err);
+                return ExitCode::FAILURE;
+            }
+        }
         cli::Commands::Ui => {
             let native_options = eframe::NativeOptions {
                 viewport: egui::ViewportBuilder::default()
@@ -167,13 +228,16 @@ async fn main() {
                 // ),
                 ..Default::default()
             };
-            eframe::run_native(
+            if let Err(err) = eframe::run_native(
                 "Manga Image Translator",
                 native_options,
                 Box::new(|cc| Ok(Box::new(ui::MitApp::new(cc)))),
-            )
-            .expect("Failed to run egui");
-            return;
+            ) {
+                error!("Failed to run egui: {}", err);
+                return ExitCode::FAILURE;
+            }
         }
     }
+
+    ExitCode::SUCCESS
 }


### PR DESCRIPTION
### Motivation
- Prevent unexpected panics in the `simple-runtime` entrypoint and API handlers by replacing `unwrap`/`expect` calls with explicit error handling and logging.

### Description
- Change `main` to return `ExitCode` and fail gracefully on fatal startup errors instead of panicking (file: `crates/runtimes/simple-runtime/src/main.rs`).
- Parse the ORT log directive without `unwrap` and log/exit on parse failure (file: `crates/runtimes/simple-runtime/src/main.rs`).
- Add error handling and logging for config file existence, `Config::builder().build()` failures, debug directory creation, per-image processing (`models.execute`), and output directory/file write failures (file: `crates/runtimes/simple-runtime/src/main.rs`).
- Handle errors from starting the API server and the egui UI rather than calling `unwrap`/`expect` (file: `crates/runtimes/simple-runtime/src/main.rs`).
- Replace `serde_json::to_string(...).unwrap()` in default API endpoints with match-based handling that returns HTTP 500 and a clear message on serialization failure (file: `crates/runtimes/simple-runtime/src/api.rs`).

### Testing
- Ran `cargo fmt` which completed successfully.
- Ran `cargo check -p simple-runtime` which could not complete in this environment because `ort-sys` attempted to download ONNX runtime and failed due to a network/proxy error: `CONNECT proxy failed: proxy server responded 403/403`.
- No additional automated tests were added or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995bf61d8f4832fb67f305721d3bf24)